### PR TITLE
Patch set to allow generalization of the library

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,12 +3,13 @@
 
 all: test test-ipv6
 
-COMMON=radix.c
+CFLAGS=-g -DRADIXTREE_DEBUG -DLSB_FIRST
+COMMON=radix.c radix.h
 test: $(COMMON) test.c
-	gcc -g -DLSB_FIRST radix.c test.c -o $@
+	gcc $(CFLAGS) radix.c test.c -o $@
 
 test-ipv6: $(COMMON)  test-ipv6.c
-	gcc -g -DLSB_FIRST radix.c test-ipv6.c -o $@
+	gcc $(CFLAGS) radix.c test-ipv6.c -o $@
 
 check: test-ipv6
 	./test-ipv6

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,14 @@
 # Radix Tree Makefile
 # Josh Allmann <joshua.allmann@gmail.com>
 
-default:
-	gcc -g -DLSB_FIRST radix.c test.c
+all: test test-ipv6
+
+COMMON=radix.c
+test: $(COMMON) test.c
+	gcc -g -DLSB_FIRST radix.c test.c -o $@
+
+test-ipv6: $(COMMON)  test-ipv6.c
+	gcc -g -DLSB_FIRST radix.c test-ipv6.c -o $@
+
+check: test-ipv6
+	./test-ipv6

--- a/Makefile
+++ b/Makefile
@@ -12,3 +12,6 @@ test-ipv6: $(COMMON)  test-ipv6.c
 
 check: test-ipv6
 	./test-ipv6
+
+clean:
+	rm -f test-ipv6 test *~

--- a/radix.c
+++ b/radix.c
@@ -45,7 +45,7 @@ static int count_common_bits(char *k1, char *k2, int max)
     int count = max;
     // XXX SIMD-ify?
 
-    while (*k1 == *k2 && count >= sizeof(int) * 8) {
+    while (count >= sizeof(long) * 8 && *k1 == *k2) {
         long *i1 = (long*)k1, *i2 = (long*)k2;
         if (*i1 == *i2) {
             k1 += sizeof(long);
@@ -53,7 +53,7 @@ static int count_common_bits(char *k1, char *k2, int max)
             count -= sizeof(long) * 8;
         } else break;
     }
-    while (*k1 == *k2 && count >= 8) {
+    while (count >= 8 && *k1 == *k2) {
         k1++;
         k2++;
         count -= 8;
@@ -218,7 +218,7 @@ int rxt_put2(void *key, int ksize, void *value, rxt_node *n)
     nl = malloc(sizeof(rxt_node)); \
     if (!nl) return -1; \
     memcpy(nl->keycache, k, ksize); \
-    nl->key = nl->keycache; \
+    nl->key = (void*)nl->keycache; \
     nl->ksize = ksize; \
     nl->pos = (8*ksize)-1; \
     nl->value = v; \

--- a/radix.c
+++ b/radix.c
@@ -46,11 +46,11 @@ static int count_common_bits(char *k1, char *k2, int max)
     // XXX SIMD-ify?
 
     while (*k1 == *k2 && count >= sizeof(int) * 8) {
-        int *i1 = (int*)k1, *i2 = (int*)k2;
+        long *i1 = (long*)k1, *i2 = (long*)k2;
         if (*i1 == *i2) {
-            k1 += sizeof(int);
-            k2 += sizeof(int);
-            count -= sizeof(int) * 8;
+            k1 += sizeof(long);
+            k2 += sizeof(long);
+            count -= sizeof(long) * 8;
         } else break;
     }
     while (*k1 == *k2 && count >= 8) {

--- a/radix.c
+++ b/radix.c
@@ -44,6 +44,7 @@ static int count_common_bits(char *k1, char *k2, int max)
 {
     int count = max;
     // XXX SIMD-ify?
+
     while (*k1 == *k2 && count >= sizeof(int) * 8) {
         int *i1 = (int*)k1, *i2 = (int*)k2;
         if (*i1 == *i2) {
@@ -57,8 +58,10 @@ static int count_common_bits(char *k1, char *k2, int max)
         k2++;
         count -= 8;
     }
-
-    return max - count_bits(k1, k2, count);
+    if (count > 0)
+        return max - count_bits(k1, k2, count);
+    else
+        return max;
 }
 
 #ifndef LSB_FIRST
@@ -112,6 +115,7 @@ static int insert_leaf(rxt_node *newleaf, rxt_node *sibling, rxt_node *parent)
         inner->left = parent->left;
         inner->right = parent->right;
         inner->key = parent->key;
+        inner->ksize = parent->ksize;
         inner->pos = parent->pos;
         parent->pos = idx;
         parent->left->parent = inner;
@@ -136,7 +140,8 @@ static int insert_leaf(rxt_node *newleaf, rxt_node *sibling, rxt_node *parent)
         // Check for duplicates.
         // FIXME feels hackish; do this properly.
         if (newleaf->pos == sibling->pos &&
-            !strncmp(newleaf->key, sibling->key, newleaf->pos)) {
+            newleaf->ksize <= sibling->ksize &&
+            !memcmp(newleaf->key, sibling->key, newleaf->ksize)) {
             free(newleaf);
             return -1;
         }
@@ -148,6 +153,7 @@ static int insert_leaf(rxt_node *newleaf, rxt_node *sibling, rxt_node *parent)
         inner->parent = parent;
         inner->pos = idx;
         inner->key = sibling->key;
+        inner->ksize = sibling->ksize;
         newleaf->parent = inner;
         sibling->parent = inner;
 
@@ -201,24 +207,20 @@ static int insert_internal(rxt_node *newleaf, rxt_node *n)
     return -1; // this should never happen
 }
 
-static inline int keylen(char *str)
-{
-    int len = strlen(str);
-    if (len < 0 || len >= RADIXTREE_KEYSIZE)
-        fprintf(stderr, "Warning: rxt key (%d) exceeds limit (%d)\n",
-                len, RADIXTREE_KEYSIZE);
-    return 8 * (len + 1) - 1;
-}
-
 int rxt_put(char *key, void *value, rxt_node *n)
 {
-#define NEWLEAF(nl, k, v) \
+    return rxt_put2(key, strlen(key)+1, value, n);
+}
+
+int rxt_put2(void *key, int ksize, void *value, rxt_node *n)
+{
+#define NEWLEAF(nl, k, ksize, v) \
     nl = malloc(sizeof(rxt_node)); \
     if (!nl) return -1; \
-    strncpy(nl->keycache, k, RADIXTREE_KEYSIZE); \
-    nl->keycache[RADIXTREE_KEYSIZE-1] = '\0'; \
+    memcpy(nl->keycache, k, ksize); \
     nl->key = nl->keycache; \
-    nl->pos = keylen(k); \
+    nl->ksize = ksize; \
+    nl->pos = (8*ksize)-1; \
     nl->value = v; \
     nl->color = 1; \
     nl->parent = n; \
@@ -226,7 +228,14 @@ int rxt_put(char *key, void *value, rxt_node *n)
     nl->right = NULL
 
     rxt_node *newleaf;
-    NEWLEAF(newleaf, key, value);
+
+    if (ksize < 1 || ksize >= sizeof(n->keycache)) {
+        fprintf(stderr, "Warning: rxt key (%d) exceeds limit (%d)\n",
+                ksize, RADIXTREE_KEYSIZE);
+        return -1;
+    }
+
+    NEWLEAF(newleaf, key, ksize, value);
 
     // this special case takes care of the first two entries
     if (!(n->left || n->right)) {
@@ -246,7 +255,6 @@ int rxt_put(char *key, void *value, rxt_node *n)
         bits = count_common_bits(key, sib->key,
                     rdx_min(newleaf->pos, sib->pos));
 
-
         if (get_bit_at(key, bits)) {
             n->right = newleaf;
             n->left = sib;
@@ -256,6 +264,7 @@ int rxt_put(char *key, void *value, rxt_node *n)
         }
         n->value = NULL;
         n->key = sib->key;
+        n->ksize = sib->ksize;
         n->pos = bits;
         n->color = 0;
         return 0;
@@ -268,20 +277,20 @@ int rxt_put(char *key, void *value, rxt_node *n)
 #undef NEWLEAF
 }
 
-static rxt_node* get_internal(char *key, rxt_node *root)
+static rxt_node* get_internal(void *key, int ksize, rxt_node *root)
 {
     if (!root) return NULL;
 
     if (root->color) {
         if (2 == root->color) root = root->value;
-        if (!strncmp(key, root->key, root->pos))
+        if (root->ksize <= ksize && !memcmp(key, root->key, root->ksize))
             return root;
         return NULL;
     }
 
     if (get_bit_at(key, root->pos))
-        return get_internal(key, root->right);
-    return get_internal(key, root->left);
+        return get_internal(key, ksize, root->right);
+    return get_internal(key, ksize, root->left);
 }
 
 static void reset_key(char *key, char *newkey, rxt_node *n)
@@ -328,8 +337,13 @@ static void *delete_internal(rxt_node *n, rxt_node *sibling)
 
 void* rxt_delete(char *key, rxt_node *root)
 {
+	return rxt_delete2(key, strlen(key)+1, root);
+}
+
+void* rxt_delete2(void *key, int ksize, rxt_node *root)
+{
     rxt_node *parent, *grandparent;
-    rxt_node *n = get_internal(key, root);
+    rxt_node *n = get_internal(key, ksize, root);
     void *v;
     char *newkey;
     if (!n) return NULL; // nonexistent
@@ -405,7 +419,12 @@ void rxt_free(rxt_node *root)
 
 void* rxt_get(char *key, rxt_node *root)
 {
-    rxt_node *n = get_internal(key, root);
+    return rxt_get2(key, strlen(key)+1, root);
+}
+
+void* rxt_get2(void *key, int ksize, rxt_node *root)
+{
+    rxt_node *n = get_internal(key, ksize, root);
     if (!n) return NULL;
     return n->value;
 }

--- a/radix.h
+++ b/radix.h
@@ -10,8 +10,10 @@ typedef struct rxt_node {
     void *value;
     int pos; // bit index of the key to compare at (critical position)
     long keycache[RADIXTREE_KEYSIZE/sizeof(long)];
+#ifdef RADIXTREE_DEBUG
     int level; // tree level; for debug only
     int parent_id; //for debug only
+#endif
     struct rxt_node *parent;
     struct rxt_node *left;
     struct rxt_node *right;

--- a/radix.h
+++ b/radix.h
@@ -6,6 +6,7 @@
 typedef struct rxt_node {
     int color;
     char *key;
+    int ksize;
     void *value;
     int pos; // bit index of the key to compare at (critical position)
     char keycache[RADIXTREE_KEYSIZE];
@@ -19,6 +20,11 @@ typedef struct rxt_node {
 int rxt_put(char*, void *, rxt_node*);
 void* rxt_get(char*, rxt_node*);
 void* rxt_delete(char*, rxt_node*);
+
+int rxt_put2(void *key, int ksize, void *value, rxt_node *n);
+void* rxt_get2(void*, int ksize, rxt_node*);
+void* rxt_delete2(void*, int ksize, rxt_node*);
+
 void rxt_free(rxt_node *);
 rxt_node *rxt_init();
 

--- a/radix.h
+++ b/radix.h
@@ -9,7 +9,7 @@ typedef struct rxt_node {
     int ksize;
     void *value;
     int pos; // bit index of the key to compare at (critical position)
-    char keycache[RADIXTREE_KEYSIZE];
+    long keycache[RADIXTREE_KEYSIZE/sizeof(long)];
     int level; // tree level; for debug only
     int parent_id; //for debug only
     struct rxt_node *parent;

--- a/test-ipv6.c
+++ b/test-ipv6.c
@@ -1,0 +1,202 @@
+#include <string.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <arpa/inet.h>
+
+#include "radix.h"
+
+// prints the tree level by level, for debug purposes.
+// [%d/%d] indicates the current id, and the id of the parent.
+// (%s) indicates an inner node's key.
+// id is assigned in the order read from the queue.
+// XXX only use this for debugging small (<50key) trees!
+static void print_tree(rxt_node * root)
+{
+    int i, write = 0, read = 0, prev_level = -1;
+    rxt_node *queue[100];
+    for (i = 0; i < 100; i++)
+	queue[i] = NULL;
+    root->parent_id = read;
+    root->level = 0;
+    queue[write++] = root;
+
+    while (read != write) {
+	char ip[64] = "";
+	char ipv6[16];
+	rxt_node *n = queue[read++];
+	// insert linebreak if needed
+
+	if (prev_level != n->level) {
+	    printf("\n\nlevel %d:\n", n->level);
+	    prev_level = n->level;
+	}
+
+	memset(ipv6, 0, sizeof(ipv6));
+	memcpy(ipv6, n->key, n->ksize);
+	inet_ntop(AF_INET6, ipv6, ip, sizeof(ip));
+
+	if (n->color)
+	    printf("[size: %d] %s[%d/%d] , ", n->ksize, ip, read, n->parent_id);
+	else {
+	    if (n->value) {
+		printf("%d (%s)[%d/%d] ,", n->pos, ip, read, n->parent_id);
+	    } else
+		printf("%d (%s)[%d/%d] , ", n->pos, ip, read,
+		       n->parent_id);
+
+	    if (n->left) {
+		rxt_node *left = n->left;
+		left->level = n->level + 1;
+		left->parent_id = read;
+		queue[write++] = left;
+	    }
+	    if (n->right) {
+		rxt_node *right = n->right;
+		right->level = n->level + 1;
+		right->parent_id = read;
+		queue[write++] = right;
+	    }
+	}
+    }
+    printf("\n");
+}
+
+static char *reverse(char *c)
+{
+    int len = strlen(c), i;
+    char *str = malloc(len + 1);
+    for (i = 0; i < len; i++)
+	str[i] = c[len - i - 1];
+    str[len] = '\0';
+    return str;
+}
+
+static int count_comparisons(rxt_node * root)
+{
+    if (!root || root->color)
+	return 0;
+    return root->pos + count_comparisons(root->left) +
+	count_comparisons(root->right);
+}
+
+static void print_in_order(rxt_node * root)
+{
+    if (!root)
+	return;
+    if (root->color) {
+	if (2 == root->color)
+	    root = root->value;
+	printf("%s: %s\n", root->key, (char *) root->value);
+	return;
+    }
+    print_in_order(root->left);
+    print_in_order(root->right);
+}
+
+static void print_value(char *key, rxt_node * root)
+{
+    char ip[64];
+    char *value = rxt_get(key, root);
+    if (value) {
+	inet_ntop(AF_INET6, key, ip, sizeof(ip));
+	printf("%s: %s\n", ip, value);
+    } else
+	printf("%s: NOT FOUND\n", key);
+}
+
+static int insert(const char *addr, unsigned prefix, rxt_node * root,
+		   char *val)
+{
+    struct in6_addr in;
+
+    if (inet_pton(AF_INET6, addr, &in) != 1)
+	exit(1);
+    return rxt_put2(in.s6_addr, prefix / 8, strdup(val), root);
+}
+
+static void *get(const char *addr, unsigned prefix, rxt_node * root)
+{
+    struct in6_addr in;
+
+    if (inet_pton(AF_INET6, addr, &in) != 1)
+	exit(1);
+    return rxt_get2(in.s6_addr, prefix / 8, root);
+}
+
+struct addresses_st {
+    const char *address;
+    unsigned prefix;
+};
+
+static struct addresses_st addresses[] = {
+    {.address = "fc44:a988:a40:9600::",
+     .prefix = 128},
+    {.address = "fc6b:aa00::1",
+     .prefix = 128},
+    {.address = "fc44:a988:a40:9600::1",
+     .prefix = 128},
+    {.address = "fd97:16e4:f54e:5fc6:d101:09d2:f2f8:bb29",
+     .prefix = 128},
+    {.address = "fc9c:6c27:9cf9:cf80:a0df:93ad:f131:ed76",
+     .prefix = 128},
+    {.address = "fc0c:94fd:dabe:49aa:752e:aa76:eccc:b33b",
+     .prefix = 128},
+    {.address = "fce7:c0a7:f570:0584:2277:668e:7763:2905",
+     .prefix = 128},
+    {.address = "fdbe:63d9:afd4:6694:dd84:738c:8a5c:fd67",
+     .prefix = 128},
+    {.address = "fde8:b1dc:9bb2:dc8c:b0dc:8d2e:ef41:9c50",
+     .prefix = 128},
+    {.address = "fc44:a988:a40:9600::",
+     .prefix = 56},
+    {.address = "fde8:b1dc::",
+     .prefix = 24},
+    {.address = "fc6b:aa00::",
+     .prefix = 24},
+    {.address = NULL,
+     .prefix = 0}
+};
+
+int main(int argc, char **argv)
+{
+    rxt_node *root = rxt_init();
+    unsigned i;
+    const char *v;
+
+    for (i = 0;; i++) {
+	if (addresses[i].address == NULL)
+	    break;
+	if (insert
+	    (addresses[i].address, addresses[i].prefix, root,
+	     "xx") != 0) {
+	    fprintf(stderr, "%d: error in %d\n", i, __LINE__);
+	    exit(1);
+	}
+    }
+
+    print_tree(root);
+
+    /* verify that everything is present */
+    for (i = 0;; i++) {
+	if (addresses[i].address == NULL)
+	    break;
+	v = get(addresses[i].address, addresses[i].prefix, root);
+	if (v == NULL) {
+	    fprintf(stderr, "cannot find %s/%d\n", addresses[i].address,
+		    addresses[i].prefix);
+	    exit(1);
+	}
+	if (strcmp(v, "xx") != 0) {
+	    fprintf(stderr, "%d: error in %d\n", i, __LINE__);
+	    exit(1);
+	}
+    }
+
+    printf("---------------\n");
+    //print_in_order(&root);
+    printf("COMPARISONS: %d\n", count_comparisons(root));
+
+    rxt_free(root);
+
+    return 0;
+}


### PR DESCRIPTION
This patch set attempts to allow the usage of the radix search with non-string keys. My goal is to attempt using it with IPv6 addresses. I've tried to keep the original assumptions when possible, as well as optimize (e.g., by taking advantage of 64-bit long). I am not very familiar with the algorithm and I'd appreciate some review. 

A part confusing to me was the strncmp() call with bit length as input.
